### PR TITLE
Added examples folder and excluded that and other files from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+build/Makefile
+build/binding.Makefile
+build/config.gypi
+build/gi.target.mk
+examples
+src
+.gitignore
+binding.gyp

--- a/examples/hello-gtk.js
+++ b/examples/hello-gtk.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+var
+  GNode = require('../lib/gnode'),
+  Gtk = GNode.importNS('Gtk'),
+  win
+;
+
+GNode.startLoop();
+Gtk.init(0, null);
+ 
+win = new Gtk.Window({
+  title: 'gnode',
+  window_position: Gtk.WindowPosition.CENTER
+});
+
+win.connect('show', Gtk.main);
+win.connect('destroy', Gtk.main_quit);
+
+win.set_default_size(200, 80);
+win.add(new Gtk.Label({label: 'Hello Gtk+'}));
+
+win.show_all();

--- a/examples/test.js
+++ b/examples/test.js
@@ -1,5 +1,5 @@
 
-const GNode = require('gnode');
+const GNode = require('../lib/gnode');
 GNode.startLoop();
 
 const GLib = GNode.importNS("GLib");


### PR DESCRIPTION
Mostly just some gardening, in case this module would ever land in `npm` (it should) we need an `.npmignore` that doesn't bring in files used to test or simply as examples.

I have created the examples folders and moved `test.js` and created an `hello-gtk.js` file so it's instantly visible and clear if the build and the module works or not.

### About changing this project name
Nowadays it's very difficult to find a free slot in `npm` registry and after filing an issue with them about a death project, I've managed to grab [node-gtk](https://www.npmjs.com/package/node-gtk)

I wouldn't mind adding all related files to [this repository](https://github.com/WebReflection/node-gtk) updating license and adding contributors (you and whoever would like to) so that it's detached from GNOME and we can move on a bit faster.

What do you think?